### PR TITLE
Hab based installation of chef-infra-client

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -43,7 +43,7 @@ module Kitchen
       default_config :chef_image, "chef/chef"
       default_config :chef_version, "latest"
       default_config :habitat_image, "ashiqueps/chef-habitat"
-      default_config :habitat_version, "19.0.35"
+      default_config :habitat_image_version, "19.0.35"
       default_config :data_image, "dokken/kitchen-cache:latest"
       default_config :dns, nil
       default_config :dns_search, nil
@@ -626,7 +626,7 @@ module Kitchen
       end
 
       def installer_image
-        return "#{config[:habitat_image]}:#{config[:habitat_version]}" if installer == "habitat"
+        return "#{config[:habitat_image]}:#{config[:habitat_image_version]}" if installer == "habitat"
 
         "#{config[:chef_image]}:#{chef_version}"
       end

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -39,7 +39,7 @@ module Kitchen
       default_config :cap_add, nil
       default_config :cap_drop, nil
       default_config :cgroupns_host, false
-      default_config :chef_image, "ashiqueps/chef-habitat"
+      default_config :chef_image, "chef/chef-hab"
       default_config :chef_version, "latest"
       default_config :data_image, "dokken/kitchen-cache:latest"
       default_config :dns, nil
@@ -117,8 +117,10 @@ module Kitchen
         dokken_delete_sandbox
       end
 
+      # TODO: This method currently checks if the installer is a hab or omnibus based on the image name.
+      # Find a better way to determine the installer.
       def installer
-        @installer ||= if config[:chef_image].include?("habitat")
+        @installer ||= if config[:chef_image].include?("hab")
                          "habitat"
                        else
                          "chef"

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -31,6 +31,7 @@ module Kitchen
 
       default_config :root_path, "/opt/kitchen"
       default_config :chef_binary, "/opt/chef/bin/chef-client"
+      default_config :hab_chef_binary, "/hab/hab_bin"
       default_config :chef_options, " -z"
       default_config :chef_log_level, "warn"
       default_config :chef_output_format, "doc"
@@ -102,14 +103,15 @@ module Kitchen
       # patching Kitchen::Provisioner::ChefZero#run_command
       def run_command
         validate_config
-        cmd = config[:chef_binary]
+        cmd = chef_executable
         cmd << config[:chef_options].to_s
         cmd << " -l #{config[:chef_log_level]}"
         cmd << " -F #{config[:chef_output_format]}"
         cmd << " -c /opt/kitchen/client.rb"
         cmd << " -j /opt/kitchen/dna.json"
-        cmd << "--profile-ruby" if config[:profile_ruby]
-        cmd << "--slow-report" if config[:slow_resource_report]
+        cmd << " --profile-ruby" if config[:profile_ruby]
+        cmd << " --slow-report" if config[:slow_resource_report]
+        cmd << " --chef-license-key=#{config[:chef_license_key]}" if instance.driver.installer == "habitat" && config[:chef_license_key]
 
         chef_cmd(cmd)
       end
@@ -127,6 +129,12 @@ module Kitchen
 
         debug("Cleaning up local sandbox in #{sandbox_path}")
         FileUtils.rmtree(Dir.glob("#{sandbox_path}/*"))
+      end
+
+      def chef_executable
+        return "HAB_LICENSE='accept-no-persist' #{config[:hab_chef_binary]} pkg exec ashiqueps/chef-infra-client -- chef-client " if instance.driver.installer == "habitat"
+
+        "#{config[:chef_binary]}"
       end
     end
   end

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -31,7 +31,7 @@ module Kitchen
 
       default_config :root_path, "/opt/kitchen"
       default_config :chef_binary, "/opt/chef/bin/chef-client"
-      default_config :hab_chef_binary, "/hab/hab_bin"
+      default_config :hab_chef_binary, "/hab/hab"
       default_config :chef_options, " -z"
       default_config :chef_log_level, "warn"
       default_config :chef_output_format, "doc"

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -132,7 +132,7 @@ module Kitchen
       end
 
       def chef_executable
-        return "HAB_LICENSE='accept-no-persist' #{config[:hab_chef_binary]} pkg exec ashiqueps/chef-infra-client -- chef-client " if instance.driver.installer == "habitat"
+        return "HAB_LICENSE='accept-no-persist' #{config[:hab_chef_binary]} pkg exec chef/chef-infra-client -- chef-client " if instance.driver.installer == "habitat"
 
         "#{config[:chef_binary]}"
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR add the following:

- By default, the chef/chef-habitat image will be used to setup chef-infra-client, which will be using the habitat-based installation.
- If the user needs, he can setup a flag in kitchen.yml file to use the chef/chef docker image which is an omnibus version of the chef infra client. Note that in this option, infra 19 will not be available.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
