### PR TITLE
[CHEF-18291] Fix the kitchen failures on windows 

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -404,7 +404,7 @@ module Kitchen
             debug "driver - error :#{e}:"
           end
         ensure
-          lockfile.unlock
+          lockfile.unlock if lockfile.locked?
         end
       end
 

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -4,8 +4,8 @@ module Dokken
     require "socket" unless defined?(Socket)
     require "timeout" unless defined?(Timeout)
     require "resolv" unless defined?(Resolv)
-    require "rubygems/package"
-    require "stringio"
+    require "rubygems/package" unless defined?(Gem::Package)
+    require "stringio" unless defined?(StringIO)
 
     def port_open?(ip, port)
       begin
@@ -107,18 +107,17 @@ module Dokken
     def build_docker_image_from_tar(docker_file_content, keys_content)
       tar_io = StringIO.new
       Gem::Package::TarWriter.new(tar_io) do |tar|
-        tar.add_file_simple('Dockerfile', 0644, docker_file_content.bytesize) do |io|
+        tar.add_file_simple("Dockerfile", 0644, docker_file_content.bytesize) do |io|
           io.write docker_file_content
         end
 
-        tar.add_file_simple('authorized_keys', 0644, keys_content.bytesize) do |io|
+        tar.add_file_simple("authorized_keys", 0644, keys_content.bytesize) do |io|
           io.write keys_content
         end
       end
 
       tar_io.rewind
 
-      # Pass the tarball to Docker
       Docker::Image.build_from_tar(tar_io)
     end
 
@@ -187,7 +186,9 @@ module Dokken
       # refs:
       # https://github.com/docker/machine/issues/1814
       # https://github.com/docker/toolbox/issues/607
-      return Dir.home.sub "C:/Users", "/c/Users" if Dir.home =~ /^C:/ && remote_docker_host?
+      #
+      # home_dir method is no longer used in other than the lockfiles and sandbox dir.
+      # return Dir.home.sub "C:/Users", "/c/Users" if Dir.home =~ /^C:/ && remote_docker_host?
 
       Dir.home
     end

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -170,14 +170,14 @@ module Kitchen
                                remote,
                                recursive: true,
                                ssh: { port: ssh_port, keys: ["#{tmpdir}/id_rsa"] })
+              debug "Copied #{local} to #{remote}"
             end
           end
         end
 
         def login_command
           @runner = options[:instance_name].to_s
-          cols = `tput cols`
-          lines = `tput lines`
+          lines, cols = IO.console.winsize
           args = ["exec", "-e", "COLUMNS=#{cols}", "-e", "LINES=#{lines}", "-it", @runner, "/bin/bash", "-login", "-i"]
           LoginCommand.new(options[:login_command], args)
         end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The kitchen was failing when the kitchen-dokken was running on the windows machine where the docker host is remote. This PR fixes the issues with the kitchen-dokken driver on windows. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
