### PR TITLE
Revert inherited code and support chef image based on client version 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,34 @@
+---
+name: integration
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-linux:
+    runs-on: ubuntu-latest
+    needs: lint-unit
+    name: Kitchen Verify
+    strategy:
+      matrix:
+        ruby: ["3.3"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Create & Validate containers
+        run: |
+          bundle exec bundle exec kitchen create hello
+          bundle exec bundle exec kitchen test helloagain
+          bundle exec bundle exec kitchen destroy hello
+        env:
+          CHEF_LICENSE: "accept-no-persist"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  chefstyle:
+  cookstyle:
     env:
       BUNDLE_WITH: ${{ inputs.bundle_with }}
     runs-on: ubuntu-latest
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.3"]
-    name: Chefstyle on Ruby
+    name: Cookstyle on Ruby
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,9 +40,9 @@ jobs:
           bundler-cache: true
       - uses: r7kamura/rubocop-problem-matchers-action@v1
         if: steps.check.outputs.gemfile == 'true'
-      - name: Chef Style
+      - name: Cookstyle
         if: steps.check.outputs.gemfile == 'true'
-        run: bundle exec chefstyle
+        run: bundle exec cookstyle --chefstyle
 
   yamllint:
     runs-on: ubuntu-latest

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,6 @@
+---
+config:
+  line-length: false  # MD013
+  no-duplicate-heading: false  # MD024
+ignores:
+  - .github/copilot-instructions.md

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,0 @@
-default: true
-MD004: false
-MD012: false
-MD013: false
-MD024: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,6 @@
 ---
-require:
-  - chefstyle
-
 AllCops:
+  TargetRubyVersion: 3.1
   Include:
     - "**/*.rb"
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/gem_tasks"
-require "chefstyle"
+require "cookstyle"
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new(:style) do |task|

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -39,7 +39,14 @@ module Kitchen
       default_config :cap_add, nil
       default_config :cap_drop, nil
       default_config :cgroupns_host, false
-      default_config :chef_image, "chef/chef-hab"
+      default_config :chef_image do |driver|
+        version = driver[:chef_version].split(".").first
+        if version.match? /\A\d+\z/ && version.to_i < 19
+          "chef/chef"
+        else
+          "chef/chef-hab"
+        end
+      end
       default_config :chef_version, "latest"
       default_config :data_image, "dokken/kitchen-cache:latest"
       default_config :dns, nil
@@ -116,16 +123,6 @@ module Kitchen
         delete_runner_container
         delete_work_image
         dokken_delete_sandbox
-      end
-
-      # TODO: This method currently checks if the installer is a hab or omnibus based on the image name.
-      # Find a better way to determine the installer.
-      def installer
-        @installer ||= if config[:chef_image].include?("hab")
-                         "habitat"
-                       else
-                         "chef"
-                       end
       end
 
       private
@@ -652,7 +649,7 @@ module Kitchen
       end
 
       def chef_container_name
-        config[:platform] != "" ? "#{installer}-#{chef_version}-" + config[:platform].sub("/", "-") : "#{installer}-#{chef_version}"
+        config[:platform] != "" ? "chef-#{chef_version}-" + config[:platform].sub("/", "-") : "chef-#{chef_version}"
       end
 
       def chef_image


### PR DESCRIPTION
## Description

This is dependent on Chef-Test-Kitchen-Enterprise PR https://github.com/chef/chef-test-kitchen-enterprise/pull/29. 
This reverts code needed for running chef-binary as that will be inherited from the ChefInfra Provisioner found in test-kitchen. This also adds a default value for chef_image based on which version of chef-client that requested making it easier to maintain support for chef-clients before 19.

Also fixing and adding additional testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
