### PR TITLE
Fix hab binary lookup to support chef/hab origin

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -133,7 +133,8 @@ module Kitchen
       def chef_executable
         return  "#{config[:chef_binary]}" if instance.driver.installer == "chef"
 
-        hab_bin = "HAB_BIN=$(find /hab/pkgs/core/hab/ -type f -name hab | sort | tail -n1)"
+        # Search both chef/hab and core/hab origins since hab moved from core to chef origin
+        hab_bin = "HAB_BIN=$(find /hab/pkgs/chef/hab/ /hab/pkgs/core/hab/ -type f -name hab 2>/dev/null | sort | tail -n1)"
         "#{hab_bin} && HAB_LICENSE='accept-no-persist'  \"$HAB_BIN\" pkg exec chef/chef-infra-client -- chef-client "
       end
 


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
The hab package moved from the 'core' origin to the 'chef' origin. The chef_executable method hardcoded 'find /hab/pkgs/core/hab/' which fails on newer Docker images that only have chef/hab installed.

Search both /hab/pkgs/chef/hab/ and /hab/pkgs/core/hab/ with stderr suppressed so the find works regardless of which origin is present.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
